### PR TITLE
(Re)Add NATIVE_TOOLKIT_STATIC_ANGLE switch to allow the angle library to be statically linked

### DIFF
--- a/include/SDL_egl.h
+++ b/include/SDL_egl.h
@@ -132,7 +132,10 @@
 *-------------------------------------------------------------------------
 * This precedes the return type of the function in the function prototype.
 */
-#if defined(_WIN32) && !defined(__SCITECH_SNAP__)
+#if defined(NATIVE_TOOLKIT_STATIC_ANGLE)
+    // not "dllimport" - just extern
+#   define KHRONOS_APICALL
+#elif defined(_WIN32) && !defined(__SCITECH_SNAP__)
 #   define KHRONOS_APICALL __declspec(dllimport)
 #elif defined (__SYMBIAN32__)
 #   define KHRONOS_APICALL IMPORT_C

--- a/src/video/SDL_egl.c
+++ b/src/video/SDL_egl.c
@@ -71,12 +71,18 @@
 #define DEFAULT_OGL_ES "libGLESv1_CM.so.1"
 #endif /* SDL_VIDEO_DRIVER_RPI */
 
+#ifdef NATIVE_TOOLKIT_STATIC_ANGLE
+// Just resolve the symbol directly
+   #define LOAD_FUNC(NAME) \
+       _this->egl_data->NAME = (void *)NAME;
+#else
 #define LOAD_FUNC(NAME) \
 _this->egl_data->NAME = SDL_LoadFunction(_this->egl_data->dll_handle, #NAME); \
 if (!_this->egl_data->NAME) \
 { \
     return SDL_SetError("Could not retrieve EGL function " #NAME); \
 }
+#endif
 
 static const char * SDL_EGL_GetErrorName(EGLint eglErrorCode)
 {
@@ -227,6 +233,8 @@ SDL_EGL_LoadLibrary(_THIS, const char *egl_path, NativeDisplayType native_displa
     }
 #endif
 
+    // Do not need to load dll if we static link ...
+    #ifndef NATIVE_TOOLKIT_STATIC_ANGLE
     /* A funny thing, loading EGL.so first does not work on the Raspberry, so we load libGL* first */
     path = SDL_getenv("SDL_VIDEO_GL_DRIVER");
     if (path != NULL) {
@@ -282,6 +290,8 @@ SDL_EGL_LoadLibrary(_THIS, const char *egl_path, NativeDisplayType native_displa
         }
         SDL_ClearError();
     }
+
+    #endif // NATIVE_TOOLKIT_STATIC_ANGLE
 
     _this->egl_data->dll_handle = dll_handle;
 


### PR DESCRIPTION
Restablish
https://github.com/native-toolkit/sdl/commit/a78c07dc1f85019261f13ebc3177cb1b144c98e4
on newer SDL version