### PR TITLE
fix Android fatal error: cpu-features.h: No such file or directory

### DIFF
--- a/files.xml
+++ b/files.xml
@@ -109,6 +109,8 @@
 
         <depend files="native-toolkit-sdl-depends"/>
 
+        <compilerflag value="-I${ANDROID_NDK_ROOT}/sources/android/cpufeatures" if="android"/>
+
         <compilerflag value="-I${NATIVE_TOOLKIT_PATH}/sdl/include/" />
         <compilerflag value="-I${NATIVE_TOOLKIT_PATH}/sdl/src/hidapi/hidapi/" />
         <compilerflag value="-I${SDL_CONFIG_PATH}" if="SDL_CONFIG_PATH" />


### PR DESCRIPTION
Determined that this needs to be handled similarly to native-toolkit/pixman:

https://github.com/native-toolkit/pixman/blob/979a51f/files.xml#L20